### PR TITLE
chore: fix space in text

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	out, err := runScan(os.Args, exec.Command)
 	if err != nil {
 		flag.Usage()
-		log.Fatal("trivy returned an error: ", err, "output: ", string(out))
+		log.Fatal("trivy returned an error: ", err, " output: ", string(out))
 	}
 
 	log.Println("sending results to webhook...")


### PR DESCRIPTION
Fix the space between `invalid arguments specifiedoutput:`

![Screen Shot 2022-08-30 at 20 28 23](https://user-images.githubusercontent.com/8355621/187561138-3f064e35-96f0-4ec3-957e-3c02fe39ebed.png)
