### PR TITLE
fix(plugin): Optionally overwrite quiet and timeout if not specified.

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,12 @@ func runScan(args []string, execCmd func(string, ...string) *exec.Cmd) ([]byte, 
 	if !containsSlice(trivyArgs, "format") {
 		trivyArgs = append(trivyArgs, []string{"--format=json"}...)
 	}
-	trivyArgs = append(trivyArgs, []string{"--quiet", "--timeout=30s"}...)
+	if !containsSlice(trivyArgs, "quiet") {
+		trivyArgs = append(trivyArgs, []string{"--quiet"}...)
+	}
+	if !containsSlice(trivyArgs, "timeout") {
+		trivyArgs = append(trivyArgs, []string{"--timeout=30s"}...)
+	}
 
 	log.Println("running trivy with args: ", trivyArgs)
 	out, err := execCmd("trivy", trivyArgs...).CombinedOutput()


### PR DESCRIPTION
Fix: specified timeout is invalid when calling trivy