### PR TITLE
Remove hardcoded args that are appended to user supplied args

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,6 @@ func runScan(args []string, execCmd func(string, ...string) *exec.Cmd) ([]byte, 
 	if !containsSlice(trivyArgs, "format") {
 		trivyArgs = append(trivyArgs, []string{"--format=json"}...)
 	}
-	trivyArgs = append(trivyArgs, []string{"--quiet", "--timeout=30s"}...)
 
 	log.Println("running trivy with args: ", trivyArgs)
 	out, err := execCmd("trivy", trivyArgs...).CombinedOutput()


### PR DESCRIPTION
There are cases where a user would like to increase the scan timeout and/or have more verbosity in the log output but cannot due to these hardcoded arguments:

`2024/01/23 19:19:47 running trivy with args:  [image --timeout 15m --format json --ignore-unfixed --vuln-type os,library --severity CRITICAL --input projects:latest --quiet --timeout=30s]`

Is there a reason for forcefully appending these arguments that are not readily obvious?